### PR TITLE
HOTT-4305: Adds job to persist appendix 5a in development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,24 +79,33 @@ workflows:
     jobs:
       - produce-appendix-5a:
           context: trade-tariff
-          name: 'development'
-          bucket_name: trade-tariff-persistence-development
-          filters:
-            branches:
-              only:
-                - main
-      - produce-appendix-5a:
-          context: trade-tariff
-          name: 'staging'
-          bucket_name: trade-tariff-persistence-staging
-          filters:
-            branches:
-              only:
-                - main
-      - produce-appendix-5a:
-          context: trade-tariff
           name: 'production'
           bucket_name: trade-tariff-persistence-production
+          filters:
+            branches:
+              only:
+                - main
+
+      - produce-appendix-5a:
+          context: trade-tariff-appendix-5a-development
+          name: 'new-aws-development'
+          bucket_name: trade-tariff-persistence-844815912454
+          filters:
+            branches:
+              only:
+                - main
+      - produce-appendix-5a:
+          context: trade-tariff-appendix-5a-staging
+          name: 'new-aws-staging'
+          bucket_name: trade-tariff-persistence-451934005581
+          filters:
+            branches:
+              only:
+                - main
+      - produce-appendix-5a:
+          context: trade-tariff-appendix-5a-production
+          name: 'new-aws-production'
+          bucket_name: trade-tariff-persistence-382373577178
           filters:
             branches:
               only:


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4305

### What?

I have added/removed/altered:

- [x] Added job for persisting appendix 5a for development
- [x] Added job for persisting appendix 5a for staging
- [x] Added job for persisting appendix 5a for production

### Why?

I am doing this because:

- This is required to make sure we're populating the latest appendix 5a data
