### PR TITLE
HMRC-670 Remove 'appendix 5a' jobs and infrastructure for CHIEF guidance

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,6 @@
 # URLs
 URL_UNION="https://www.gov.uk/government/publications/data-element-23-documents-and-other-reference-codes-union-of-the-customs-declaration-service-cds"
 URL_NATIONAL="https://www.gov.uk/guidance/data-element-23-documents-and-other-reference-codes-national-of-the-customs-declaration-service-cds"
-URL_CHIEF="https://www.gov.uk/government/publications/uk-trade-tariff-document-certificate-and-authorisation-codes-for-harmonised-declarations"
 URL_5B="https://www.gov.uk/government/publications/uk-trade-tariff-document-status-codes-for-harmonised-declarations/uk-trade-tariff-document-status-codes-for-harmonised-declarations"
 # Destinations
-DEST_FILE="chief_cds_guidance.json"
+DEST_FILE="cds_guidance.json"

--- a/.gitignore
+++ b/.gitignore
@@ -115,7 +115,7 @@ resources/02. overlays/cds/*.md
 resources/02. overlays/cds archive
 resources/02. overlays/chief/*.md
 resources/03. dest/20*
-resources/03. dest/chief_cds_guidance.json
+resources/03. dest/cds_guidance.json
 resources/04. codes/codes*
 resources/05. missing/*.json
 resources/05. missing/*.xlsx
@@ -123,4 +123,4 @@ resources/05. missing/*.xlsx
 # Shortcuts
 p
 
-chief_cds_guidance.json
+cds_guidance.json

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 ### Overview steps
 
+- CHIEF processing is now deprecated
+
 - Get hold of the latest Excel files from gov.uk
 
 - Get local overlays (if required) - this will be discussed below
@@ -38,7 +40,7 @@ In theory, there are four files that we are interested in, as follows:
 
 - A list of the UK’s document codes and instructions on how to enter them on CDS (CDS National data)
 
-- A list of CHIEF’s codes (UK and EU) and how to enter them (CHIEF data)
+- **DEPRECATED** A list of CHIEF’s codes (UK and EU) and how to enter them (CHIEF data)
 
 - A list of status codes
 
@@ -56,7 +58,7 @@ https://www.gov.uk/government/publications/data-element-23-documents-and-other-r
 
 https://www.gov.uk/guidance/data-element-23-documents-and-other-reference-codes-national-of-the-customs-declaration-service-cds
 
-**CHIEF data**
+**CHIEF data (DEPRECATED)**
 
 https://www.gov.uk/government/publications/uk-trade-tariff-document-certificate-and-authorisation-codes-for-harmonised-declarations
 
@@ -84,7 +86,7 @@ The way that the current app works is:
 
 - there is a subfolder containing overlays
 
-- one sub-subfolder for CHIEF overlays
+- **DEPRECATED** one sub-subfolder for CHIEF overlays
 
 - one sub-subfolder for CDS overlays
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-670

### What?

- [x] I have deprecated CHIEF guidance processing as this is no longer required 
- [x] Renamed output file to cds_guidance as it no longer has CHIEF guidance data.

### Why?

I am doing this because:

- HMRC do not require CHIEF data in Appendix5a Certificate Guidance anymore.
- The OTT backend has been updated to ignore CHIEF Data and accept the updated output file in this [PR](https://github.com/trade-tariff/trade-tariff-backend/pull/2132)
- The OTT frontend has been updated not to show CHIEF Guidance

Examples of Updated Output
![image](https://github.com/user-attachments/assets/eba73310-aa83-4972-bcf7-beeef247d805)

![image](https://github.com/user-attachments/assets/4bdbeb67-56b1-4dd6-b76e-b3c8d5c70f00)
