### PR TITLE
HMRC-670 Remove Chief Overlays

### DIFF
--- a/resources/02. overlays/chief/README.txt
+++ b/resources/02. overlays/chief/README.txt
@@ -1,1 +1,0 @@
-Contains CHIEF overlays


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-670

### What?

I have Removed CHIEF Overlays

### Why?

I am doing this because:

- CHIEF Guidance has been deprecated