### PR TITLE
HMRC-769 Migrate CircleCI to GitHub Actions

### DIFF
--- a/.github/workflows/week_day.yml
+++ b/.github/workflows/week_day.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: "00 21 * * 1,2,3,4,5"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   produce-appendix-5a:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Jira
[HMRC-769](https://transformuk.atlassian.net/browse/HMRC-769)

### What
Added AWS permissions to week_day 

### Why
cron jobs were failing due to insufficent permissions
